### PR TITLE
Add npm run start:fake

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ npm start
 To run the backend (port 4000) alongside the frontend, also use:
 
 ```
-//first comment out lines 12 & 13 in /src/index.jsx
-
+# Run the backend server
 cd backend
-
 npm i
-
 npm start
+
+# Then, on a new terminal, navigate to the root directory of the repo
+# and run the frontend with the following:
+npm run start:fake
 ```
 
 ## Acknowledgements

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "license": "MIT",
     "scripts": {
         "build": "webpack --mode production",
+        "start:fake": "webpack-dev-server --open --watch --watch-poll --define process.env.FAKE_BACKEND=true",
         "start": "webpack-dev-server --open --watch --watch-poll"
     },
     "dependencies": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,15 +2,16 @@ import React from 'react';
 import { Router } from 'react-router-dom';
 import { render } from 'react-dom';
 
-import { history } from './_helpers';
+import { configureFakeBackend, history } from './_helpers';
 import { accountService } from './_services';
 import { App } from './app';
 
 import './styles.less';
 
-// fake backend. comment out below two lines if using real backend
-import { configureFakeBackend } from './_helpers';
-configureFakeBackend();
+// start fake backend if running with "npm run start:fake"
+if (process.env.FAKE_BACKEND === true) {
+  configureFakeBackend();
+}
 
 // attempt silent token refresh before startup
 accountService.refreshToken().finally(startApp);


### PR DESCRIPTION
This feature allows developers to run a fake backend with `npm run start:fake`. No more commenting lines out! :D